### PR TITLE
みんかぶのスクレイピングができない問題を解消

### DIFF
--- a/backend/dividend_scraping_service/dividend_scraping_service.py
+++ b/backend/dividend_scraping_service/dividend_scraping_service.py
@@ -1,9 +1,10 @@
+import time
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
 
-from utils.chrome_driver import boot_driver
+from utils.chrome_driver import boot_driver, boot_driver_venv
 from utils.firestore_utils import get_all_document_ids, set_documents
 
 
@@ -12,6 +13,8 @@ def _process_stock(driver, ticker):
     # 配当ページへアクセス
     url_dividend = f"https://minkabu.jp/stock/{ticker}/dividend"
     driver.get(url_dividend)
+    # ページが読み込まれるまで待機する（本来はwait.untilでいいはずだが、時々うまく機能しないため別途sleepを入れている）
+    time.sleep(5)
 
     # 要素が表示されるまで待機する
     wait = WebDriverWait(driver, 10)
@@ -50,7 +53,8 @@ async def dividend_scraping():
 
         for ticker in tickers:
             dividend = _process_stock(driver, ticker)
-            results.append({"ticker": ticker, "dividend_yen": dividend})
+            if dividend is not None:
+                results.append({"ticker": ticker, "dividend_yen": dividend})
 
         # 結果をDBに登録する
         set_documents(output_collection_name, results)
@@ -59,3 +63,29 @@ async def dividend_scraping():
         print("append_dividendでエラーが発生しました: ", str(e))
     finally:
         driver.quit()
+
+
+def dividend_scraping_local():
+    driver = boot_driver_venv()
+    try:
+        results = []
+        input_collection_name = "own_stock"
+        output_collection_name = "stock_info"
+        tickers = get_all_document_ids(input_collection_name)
+
+        for ticker in tickers:
+            dividend = _process_stock(driver, ticker)
+            if dividend is not None:
+                results.append({"ticker": ticker, "dividend_yen": dividend})
+
+        # 結果をDBに登録する
+        set_documents(output_collection_name, results)
+        return "done"
+    except Exception as e:
+        print("append_dividendでエラーが発生しました: ", str(e))
+    finally:
+        driver.quit()
+
+
+if __name__ == "__main__":
+    dividend_scraping_local()

--- a/backend/utils/chrome_driver.py
+++ b/backend/utils/chrome_driver.py
@@ -4,7 +4,7 @@ from webdriver_manager.chrome import ChromeDriverManager
 
 
 # Docker環境用
-def boot_driver(download_directory):
+def boot_driver(download_directory=""):
     print("driverを起動します")
 
     # Chrome オプションの設定
@@ -15,17 +15,17 @@ def boot_driver(download_directory):
     chrome_options.add_argument("--headless")  # ヘッドレスモードを有効にする
     chrome_options.add_argument("--disable-gpu")
     chrome_options.add_argument("--disable-dev-shm-usage")
-    chrome_options.add_experimental_option(
-        "prefs",
-        {"download.default_directory": download_directory},
-    )
+    if download_directory:
+        chrome_options.add_experimental_option(
+            "prefs",
+            {"download.default_directory": download_directory},
+        )
 
     # Docker環境専用の記述
     chrome_driver_path = "/usr/local/bin/chromedriver"
 
     # ドライバーの起動
     driver = webdriver.Chrome(
-        # ChromeDriverManager().install(), Docker環境で動かすときは不要
         options=chrome_options,
         executable_path=chrome_driver_path,
     )
@@ -34,15 +34,16 @@ def boot_driver(download_directory):
 
 
 # venv環境用
-def boot_driver_venv(download_directory):
+def boot_driver_venv(download_directory=""):
     print("driverを起動します")
 
     # Chrome オプションの設定
     chrome_options = Options()
-    chrome_options.add_experimental_option(
-        "prefs",
-        {"download.default_directory": download_directory},
-    )
+    if download_directory:
+        chrome_options.add_experimental_option(
+            "prefs",
+            {"download.default_directory": download_directory},
+        )
 
     # ドライバーの起動
     driver = webdriver.Chrome(


### PR DESCRIPTION
- driver起動のメソッドを書き換えたことにより、引数が必須になっていた。これを任意の引数に変更
- ページ表示後すぐに要素を取得しようとするとうまくいかずフリーズすることがあるため、5秒の待機時間を追加